### PR TITLE
OSCServerDelegate protocol conforms to class

### DIFF
--- a/Framework/SwiftOSC/Communication/OSCServer.swift
+++ b/Framework/SwiftOSC/Communication/OSCServer.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol OSCServerDelegate {
+public protocol OSCServerDelegate: class {
     func didReceive(_ data: Data)
     func didReceive(_ bundle: OSCBundle)
     func didReceive(_ message: OSCMessage)


### PR DESCRIPTION
This will allow the user to check equality on the OSCServerDelegate. For example:
```
class MyServer {
    let server: OSCServer

    init() {
        server = OSCServer(address: "localhost", port: 8080)
        server.delegate = self
    }
}

// in a Unit Test
func testDelegate() {
    let instance = MyServer()
    XCTAssertTrue(instance.server.delegate === instance)
}
```

As of Swift 5.1, this is the only way to check for equality between protocol by conforming them to `class`.